### PR TITLE
parseRtpEncodingParameters: fix ssrc for red/ulpfec

### DIFF
--- a/sdp.js
+++ b/sdp.js
@@ -446,7 +446,7 @@ SDPUtils.parseRtpEncodingParameters = function(mediaSection) {
       if (hasRed) {
         encParam = JSON.parse(JSON.stringify(encParam));
         encParam.fec = {
-          ssrc: secondarySsrc,
+          ssrc: primarySsrc,
           mechanism: hasUlpfec ? 'red+ulpfec' : 'red'
         };
         encodingParameters.push(encParam);


### PR DESCRIPTION
this happens on the primary ssrc, not the rtx one