### PR TITLE
writeSessionBoilerplate: allow passing a 'user'

### DIFF
--- a/sdp.js
+++ b/sdp.js
@@ -562,7 +562,8 @@ SDPUtils.generateSessionId = function() {
 // sessId argument is optional - if not supplied it will
 // be generated randomly
 // sessVersion is optional and defaults to 2
-SDPUtils.writeSessionBoilerplate = function(sessId, sessVer) {
+// sessUser is optional and defaults to 'thisisadapterortc'
+SDPUtils.writeSessionBoilerplate = function(sessId, sessVer, sessUser) {
   var sessionId;
   var version = sessVer !== undefined ? sessVer : 2;
   if (sessId) {
@@ -570,9 +571,10 @@ SDPUtils.writeSessionBoilerplate = function(sessId, sessVer) {
   } else {
     sessionId = SDPUtils.generateSessionId();
   }
+  var user = sessUser || 'thisisadapterortc';
   // FIXME: sess-id should be an NTP timestamp.
   return 'v=0\r\n' +
-      'o=thisisadapterortc ' + sessionId + ' ' + version +
+      'o=' + user + ' ' + sessionId + ' ' + version +
         ' IN IP4 127.0.0.1\r\n' +
       's=-\r\n' +
       't=0 0\r\n';


### PR DESCRIPTION
instead of requiring a string-replace afterwards