### PR TITLE
Add a=rtcp-rsize to the rtp description

### DIFF
--- a/sdp.js
+++ b/sdp.js
@@ -412,6 +412,7 @@ SDPUtils.writeRtpDescription = function(kind, caps) {
     sdp += 'a=maxptime:' + maxptime + '\r\n';
   }
   sdp += 'a=rtcp-mux\r\n';
+  sdp += 'a=rtcp-rsize\r\n';
 
   if (caps.headerExtensions) {
     caps.headerExtensions.forEach(function(extension) {


### PR DESCRIPTION
rtcpParameters.reducedSize is set in [parseRtcpParameters](https://github.com/otalk/sdp/blob/master/sdp.js#L521) but rtcpParameters isn't used in [writeRtpDescription](https://github.com/otalk/sdp/blob/master/sdp.js#L414)
Chrome only add rtcp-rsize to video m-section but I don't think it will be a problem to always include it.
Alternativly we could pass rtcpParameters to writeRtpDescription or add rtcp-rsize [toSDP](https://github.com/otalk/rtcpeerconnection-jingle/blob/master/src/transform.js#L102)