### PR TITLE
v3: move to es6, remove old stuff

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -47,7 +47,7 @@
     "valid-typeof": 2
   },
   "env": {
-      "es6": false,
+      "es6": true,
       "browser": true,
       "node": true
   },

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .nyc_output/
 coverage/
+dist/

--- a/package.json
+++ b/package.json
@@ -2,13 +2,16 @@
   "name": "sdp",
   "version": "2.12.0",
   "description": "SDP parsing and serialization utilities",
-  "main": "sdp.js",
+  "main": "dist/sdp.js",
+  "module": "sdp.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/fippo/sdp.git"
   },
   "scripts": {
+    "build": "babel sdp.js --presets babel-preset-env --out-dir dist",
     "coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
+    "prepare": "npm run build",
     "test": "eslint sdp.js test/sdp.js && nyc --reporter html mocha test/sdp.js"
   },
   "keywords": [
@@ -18,10 +21,13 @@
   "author": "Philipp Hancke",
   "license": "MIT",
   "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "babel-core": "^6.26.3",
+    "babel-preset-env": "^1.7.0",
     "chai": "^4.0.0",
-    "codecov": "^3.0.4",
+    "codecov": "^3.6.5",
     "eslint": "^6.0.1",
-    "mocha": "^5.2.0",
+    "mocha": "^7.1.2",
     "nyc": "^14.1.1",
     "sinon": "^2.3.2",
     "sinon-chai": "^2.10.0"

--- a/sdp.js
+++ b/sdp.js
@@ -386,8 +386,12 @@ SDPUtils.getIceParameters = function(mediaSection, sessionpart) {
 
 // Serializes ICE parameters to SDP.
 SDPUtils.writeIceParameters = function(params) {
-  return 'a=ice-ufrag:' + params.usernameFragment + '\r\n' +
+  let sdp = 'a=ice-ufrag:' + params.usernameFragment + '\r\n' +
       'a=ice-pwd:' + params.password + '\r\n';
+  if (params.iceLite) {
+    sdp += 'a=ice-lite\r\n';
+  }
+  return sdp;
 };
 
 // Parses the SDP media section and returns RTCRtpParameters.

--- a/sdp.js
+++ b/sdp.js
@@ -466,7 +466,6 @@ SDPUtils.writeRtpDescription = function(kind, caps) {
   if (maxptime > 0) {
     sdp += 'a=maxptime:' + maxptime + '\r\n';
   }
-  sdp += 'a=rtcp-mux\r\n';
 
   if (caps.headerExtensions) {
     caps.headerExtensions.forEach(extension => {
@@ -573,6 +572,22 @@ SDPUtils.parseRtcpParameters = function(mediaSection) {
 
   return rtcpParameters;
 };
+
+SDPUtils.writeRtcpParameters = function(rtcpParameters) {
+  let sdp = '';
+  if (rtcpParameters.reducedSize) {
+    sdp += 'a=rtcp-rsize\r\n';
+  }
+  if (rtcpParameters.mux) {
+    sdp += 'a=rtcp-mux\r\n';
+  }
+  if (rtcpParameters.ssrc !== undefined && rtcpParameters.cname) {
+    sdp += 'a=ssrc:' + rtcpParameters.ssrc +
+      ' cname:' + rtcpParameters.cname + '\r\n';
+  }
+  return sdp;
+};
+
 
 // parses either a=msid: or a=ssrc:... msid lines and returns
 // the id of the MediaStream and MediaStreamTrack.

--- a/sdp.js
+++ b/sdp.js
@@ -703,60 +703,6 @@ SDPUtils.writeSessionBoilerplate = function(sessId, sessVer, sessUser) {
       't=0 0\r\n';
 };
 
-SDPUtils.writeMediaSection = function(transceiver, caps, type, stream) {
-  var sdp = SDPUtils.writeRtpDescription(transceiver.kind, caps);
-
-  // Map ICE parameters (ufrag, pwd) to SDP.
-  sdp += SDPUtils.writeIceParameters(
-    transceiver.iceGatherer.getLocalParameters());
-
-  // Map DTLS parameters to SDP.
-  sdp += SDPUtils.writeDtlsParameters(
-    transceiver.dtlsTransport.getLocalParameters(),
-    type === 'offer' ? 'actpass' : 'active');
-
-  sdp += 'a=mid:' + transceiver.mid + '\r\n';
-
-  if (transceiver.direction) {
-    sdp += 'a=' + transceiver.direction + '\r\n';
-  } else if (transceiver.rtpSender && transceiver.rtpReceiver) {
-    sdp += 'a=sendrecv\r\n';
-  } else if (transceiver.rtpSender) {
-    sdp += 'a=sendonly\r\n';
-  } else if (transceiver.rtpReceiver) {
-    sdp += 'a=recvonly\r\n';
-  } else {
-    sdp += 'a=inactive\r\n';
-  }
-
-  if (transceiver.rtpSender) {
-    // spec.
-    var msid = 'msid:' + stream.id + ' ' +
-        transceiver.rtpSender.track.id + '\r\n';
-    sdp += 'a=' + msid;
-
-    // for Chrome.
-    sdp += 'a=ssrc:' + transceiver.sendEncodingParameters[0].ssrc +
-        ' ' + msid;
-    if (transceiver.sendEncodingParameters[0].rtx) {
-      sdp += 'a=ssrc:' + transceiver.sendEncodingParameters[0].rtx.ssrc +
-          ' ' + msid;
-      sdp += 'a=ssrc-group:FID ' +
-          transceiver.sendEncodingParameters[0].ssrc + ' ' +
-          transceiver.sendEncodingParameters[0].rtx.ssrc +
-          '\r\n';
-    }
-  }
-  // FIXME: this should be written by writeRtpDescription.
-  sdp += 'a=ssrc:' + transceiver.sendEncodingParameters[0].ssrc +
-      ' cname:' + SDPUtils.localCName + '\r\n';
-  if (transceiver.rtpSender && transceiver.sendEncodingParameters[0].rtx) {
-    sdp += 'a=ssrc:' + transceiver.sendEncodingParameters[0].rtx.ssrc +
-        ' cname:' + SDPUtils.localCName + '\r\n';
-  }
-  return sdp;
-};
-
 // Gets the direction from the mediaSection or the sessionpart.
 SDPUtils.getDirection = function(mediaSection, sessionpart) {
   // Look for sendrecv, sendonly, recvonly, inactive, default to sendrecv.

--- a/sdp.js
+++ b/sdp.js
@@ -61,7 +61,7 @@ SDPUtils.parseCandidate = function(line) {
 
   var candidate = {
     foundation: parts[0],
-    component: parseInt(parts[1], 10),
+    component: {1: 'rtp', 2: 'rtcp'}[parts[1]],
     protocol: parts[2].toLowerCase(),
     priority: parseInt(parts[3], 10),
     ip: parts[4],

--- a/test/sdp.js
+++ b/test/sdp.js
@@ -562,10 +562,11 @@ describe('getIceParameters', () => {
 });
 
 describe('writeIceParameters', () => {
-  const serialized = SDPUtils.writeIceParameters({
+  const parameters = {
     usernameFragment: 'foo',
     password: 'bar'
-  });
+  };
+  const serialized = SDPUtils.writeIceParameters(parameters);
 
   it('serializes the usernameFragment', () => {
     expect(serialized).to.contain('a=ice-ufrag:foo');
@@ -573,6 +574,12 @@ describe('writeIceParameters', () => {
 
   it('serializes the password', () => {
     expect(serialized).to.contain('a=ice-pwd:bar');
+  });
+
+  it('includes ice-lite when іceLite is true', () => {
+    const lite = SDPUtils.writeIceParameters(Object.assign({}, parameters,
+      {iceLite: true}));
+    expect(lite).to.contain('a=ice-lite');
   });
 });
 

--- a/test/sdp.js
+++ b/test/sdp.js
@@ -642,7 +642,7 @@ describe('ice candidate', () => {
       expect(candidate.foundation).to.equal('702786350');
     });
     it('parses component', () => {
-      expect(candidate.component).to.equal(2);
+      expect(candidate.component).to.equal('rtcp');
     });
     it('parses priority', () => {
       expect(candidate.priority).to.equal(41819902, 'parses priority');

--- a/test/sdp.js
+++ b/test/sdp.js
@@ -471,6 +471,24 @@ describe('parseRtcpParameters', () => {
   });
 });
 
+describe('writeRtcpParameters', () => {
+  it('adds a rtcp-mux line if mux is true', () => {
+    const serialized = SDPUtils.writeRtcpParameters({mux: true});
+    expect(serialized).to.contain('a=rtcp-mux');
+  });
+
+  it('adds a rtcp-rsize line if reducedSize is true', () => {
+    const serialized = SDPUtils.writeRtcpParameters({reducedSize: true});
+    expect(serialized).to.contain('a=rtcp-rsize');
+  });
+
+  it('adds a a=ssrc line with cname if cname and ssrc are set', () => {
+    const serialized = SDPUtils.writeRtcpParameters({ssrc: 1, cname: 'foo'});
+    expect(serialized).to.contain('a=ssrc:1 cname:foo');
+  });
+});
+
+
 describe('parseFingerprint', () => {
   const res = SDPUtils.parseFingerprint('a=fingerprint:ALG fp');
   it('parses and lowercaseѕ the algorithm', () => {


### PR DESCRIPTION
breaking changes:
* candidate.component is now a string rtp/rtcp instead of 1/2. See #26 
* writeMediaSection is no more. See #30 
* writeRtpDescription no longer adds a=rtcp-mux. See #46, use writeRtcpParameters
* writeIceParameters writes a=ice-lite, see #41. Note that writing ice-lite to media sections is violating the spec and rejected by Firefox

first commit follows https://github.com/otalk/rtcpeerconnection-jingle/pull/22