### PR TITLE
parsecandidate: don't overwrite main attributes

### DIFF
--- a/sdp.js
+++ b/sdp.js
@@ -81,8 +81,10 @@ SDPUtils.parseCandidate = function(line) {
         candidate.ufrag = parts[i + 1]; // for backward compatibility.
         candidate.usernameFragment = parts[i + 1];
         break;
-      default: // extension handling, in particular ufrag
-        candidate[parts[i]] = parts[i + 1];
+      default: // extension handling, in particular ufrag. Don't overwrite.
+        if (candidate[parts[i]] === undefined) {
+          candidate[parts[i]] = parts[i + 1];
+        }
         break;
     }
   }

--- a/test/sdp.js
+++ b/test/sdp.js
@@ -717,6 +717,11 @@ describe('ice candidate', () => {
       expect(candidate.generation).to.equal('0');
     });
 
+    it('does not overwrite main attributes with extension attribues', () => {
+      expect(SDPUtils.parseCandidate(candidateString + ' type newtype').type)
+        .to.equal('relay');
+    });
+
     it('parses the candidate with the legacy a= prefix', () => {
       expect(SDPUtils.parseCandidate('a=' + candidateString).foundation)
         .to.equal('702786350');


### PR DESCRIPTION
with extension attributes. Silently drop them.